### PR TITLE
Fix/cancelpayment

### DIFF
--- a/POSSG_BE/src/main/java/possg/com/a/controller/PaymentController.java
+++ b/POSSG_BE/src/main/java/possg/com/a/controller/PaymentController.java
@@ -55,6 +55,21 @@ public class PaymentController {
 		
 		String check = "";
 		
+		// 현금 결제인 경우
+		int cashCheck = service.cashCheck(receiptId);
+		System.out.println(cashCheck);
+		
+		if (cashCheck > 0) {
+			int count = service.cancelpayment(receiptId);
+			if(count > 0) {
+				return "YES";
+			}
+			else{
+				return "CANCEL YES BUT UPDATE NO";
+			}
+		}
+		
+		
 		try {
 			
 			// REST API KEY, PRIVATE KEY
@@ -63,11 +78,14 @@ public class PaymentController {
 
 		    System.out.println("토큰: " + token.get("access_token")); // 토큰 확인
 		    
+		    
+		    
 		    // 토큰 에러 안나려면 꼭 허가 IP를 넣어줘야함 --> FIREWALL_BLOCKED때문에
 		    if(token.get("error_code") != null) { 
 		    	check = (String)token.get("error_code");
 		    	return check;
 		    }
+		    
 		    
 		    Cancel cancel = new Cancel();
 		    cancel.receiptId = receiptId;

--- a/POSSG_BE/src/main/java/possg/com/a/dao/PaymentDao.java
+++ b/POSSG_BE/src/main/java/possg/com/a/dao/PaymentDao.java
@@ -18,4 +18,5 @@ public interface PaymentDao {
 	PaymentParam paymentOneList(String receiptId);
 	int getallpayment(int convSeq);
 	List<PaymentParam> paymentNumList(String receiptId);
+	int cashCheck(String receiptId);
 }

--- a/POSSG_BE/src/main/java/possg/com/a/service/PaymentService.java
+++ b/POSSG_BE/src/main/java/possg/com/a/service/PaymentService.java
@@ -40,4 +40,8 @@ public class PaymentService {
 	public List<PaymentParam> paymentNumList(String receiptId) {
 		return dao.paymentNumList(receiptId);
 	};
+	
+	public int cashCheck(String receiptId) {
+		return dao.cashCheck(receiptId);
+	};
 }

--- a/POSSG_BE/src/main/resources/sqls/Payment.xml
+++ b/POSSG_BE/src/main/resources/sqls/Payment.xml
@@ -97,4 +97,11 @@
 		where conv_seq = #{convSeq}
 	</select>
 	
+	<!-- 현금 결제인지 체크 -->
+	<select id="cashCheck" parameterType="String" resultType="Integer">
+		SELECT count(*)
+		FROM Payment
+		WHERE receipt_id = #{receipt_id} AND pg = "현금"
+	</select>
+	
 </mapper>


### PR DESCRIPTION
## 📌 관련 이슈
- #190 


## ✨ 구현 내용
- 현금 결제인지 체크하는 메서드: checkCash
- 현금 결제일 경우 취소가 안되는 버그를 수정 --> cancelpayment에서 현금결제는 부트페이 연동이 아닌 자체적 취소이므로 부트페이 연동 실행전에 체크하고 취소 